### PR TITLE
Lint project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,7 @@ version = "0.0.4"
 dependencies = [
  "ggez",
  "structopt",
+ "thiserror",
  "xml-rs",
 ]
 

--- a/crates/inkmlrs/Cargo.toml
+++ b/crates/inkmlrs/Cargo.toml
@@ -11,4 +11,5 @@ repository = "https://github.com/justinrubek/inkmlrs"
 [dependencies]
 ggez = "0.7.0"
 structopt = "0.2"
+thiserror = "1.0.38"
 xml-rs = "0.8"

--- a/crates/inkmlrs/src/error.rs
+++ b/crates/inkmlrs/src/error.rs
@@ -4,6 +4,11 @@ use thiserror::Error;
 pub enum InkmlError {
     #[error(transparent)]
     XmlWriterError(#[from] xml::writer::Error),
+    #[error(transparent)]
+    XmlReaderError(#[from] xml::reader::Error),
+
+    #[error("Invalid InkML file")]
+    InvalidInkml,
 }
 
 pub type InkmlResult<T> = Result<T, InkmlError>;

--- a/crates/inkmlrs/src/error.rs
+++ b/crates/inkmlrs/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum InkmlError {
+    #[error(transparent)]
+    XmlWriterError(#[from] xml::writer::Error),
+}
+
+pub type InkmlResult<T> = Result<T, InkmlError>;

--- a/crates/inkmlrs/src/inkml.rs
+++ b/crates/inkmlrs/src/inkml.rs
@@ -46,14 +46,13 @@ impl<'a> Iterator for NodeIter<'a> {
 
         match next {
             Some(Node::Ink(ink)) => {
-                self.queue
-                    .extend(ink.traces.iter().map(Node::Traces));
+                self.queue.extend(ink.traces.iter().map(Node::Traces));
             }
 
             Some(Node::Traces(Traces::TraceGroup(ref trace_group))) => {
                 self.queue
                     .extend(trace_group.traces.iter().map(Node::Traces));
-            },
+            }
 
             _ => {}
         }
@@ -90,7 +89,10 @@ impl<'a> Ink {
         Ok(())
     }
 
-    fn write_tracegroup<W: Write>(w: &mut xml::EventWriter<W>, group: &TraceGroup) -> InkmlResult<()> {
+    fn write_tracegroup<W: Write>(
+        w: &mut xml::EventWriter<W>,
+        group: &TraceGroup,
+    ) -> InkmlResult<()> {
         w.write(
             XmlEvent::start_element("traceGroup")
                 .attr("contextRef", "#ctx0")
@@ -178,19 +180,19 @@ impl<'a> Ink {
             standalone: Some(true),
         })?;
         // Iterate over and write events for inner nodes
-        self.iter().map(|n| match n {
-            Node::Ink(ink) => {
-                writer.write(
-                    XmlEvent::start_element("ink").ns("inkml", "https://www.w3.org/TR/InkML"),
-                )?;
+        self.iter()
+            .map(|n| match n {
+                Node::Ink(ink) => {
+                    writer.write(
+                        XmlEvent::start_element("ink").ns("inkml", "https://www.w3.org/TR/InkML"),
+                    )?;
 
-                Ink::write_definitions(&mut writer, ink)
-            }
+                    Ink::write_definitions(&mut writer, ink)
+                }
 
-            Node::Traces(traces) => {
-                Ink::write_traces(&mut writer, traces)
-            }
-        }).collect::<InkmlResult<Vec<_>>>()?;
+                Node::Traces(traces) => Ink::write_traces(&mut writer, traces),
+            })
+            .collect::<InkmlResult<Vec<_>>>()?;
 
         writer.write(XmlEvent::end_element())?;
         Ok(())

--- a/crates/inkmlrs/src/inkml.rs
+++ b/crates/inkmlrs/src/inkml.rs
@@ -1,10 +1,10 @@
 use std::collections::VecDeque;
-use std::error::Error;
 use std::io::Write;
 
 use xml::writer::events::XmlEvent;
-use xml::{EmitterConfig, EventWriter};
+use xml::EmitterConfig;
 
+use crate::error::InkmlResult;
 use crate::parse::Point;
 
 #[derive(Debug, Default)]
@@ -45,17 +45,14 @@ impl<'a> Iterator for NodeIter<'a> {
         let next = self.queue.pop_front();
 
         match next {
-            Some(Node::Ink(ref ink)) => {
+            Some(Node::Ink(ink)) => {
                 self.queue
-                    .extend(ink.traces.iter().map(|tg| Node::Traces(tg)));
+                    .extend(ink.traces.iter().map(Node::Traces));
             }
 
-            Some(Node::Traces(ref trace_node)) => match trace_node {
-                Traces::TraceGroup(ref trace_group) => {
-                    self.queue
-                        .extend(trace_group.traces.iter().map(|tg| Node::Traces(tg)));
-                }
-                _ => {}
+            Some(Node::Traces(Traces::TraceGroup(ref trace_group))) => {
+                self.queue
+                    .extend(trace_group.traces.iter().map(Node::Traces));
             },
 
             _ => {}
@@ -67,103 +64,111 @@ impl<'a> Iterator for NodeIter<'a> {
 
 impl<'a> Ink {
     pub fn iter(&'a self) -> NodeIter<'a> {
-        (&self).into_iter()
+        self.into_iter()
     }
 
     // Add a new trace to the document
-    pub fn draw(&mut self, trace: &Vec<Point>) {
+    pub fn draw(&mut self, trace: &[Point]) {
         self.traces.push(Traces::Trace(Trace {
-            vertices: trace.clone(),
+            vertices: trace.to_owned(),
         }));
     }
 
-    fn write_trace<W: Write>(w: &mut xml::EventWriter<W>, trace: &Trace) {
+    fn write_trace<W: Write>(w: &mut xml::EventWriter<W>, trace: &Trace) -> InkmlResult<()> {
         w.write(
             XmlEvent::start_element("trace")
                 .attr("contextRef", "#ctx0")
                 .attr("brushRef", "#br0"),
-        );
+        )?;
 
         for point in &trace.vertices {
-            w.write(XmlEvent::characters(&format!("{} {},", point[0], point[1])));
+            w.write(XmlEvent::characters(&format!("{} {},", point[0], point[1])))?;
         }
 
-        w.write(XmlEvent::end_element());
+        w.write(XmlEvent::end_element())?;
+
+        Ok(())
     }
 
-    fn write_tracegroup<W: Write>(w: &mut xml::EventWriter<W>, group: &TraceGroup) {
+    fn write_tracegroup<W: Write>(w: &mut xml::EventWriter<W>, group: &TraceGroup) -> InkmlResult<()> {
         w.write(
             XmlEvent::start_element("traceGroup")
                 .attr("contextRef", "#ctx0")
                 .attr("brushRef", "#br0"),
-        );
+        )?;
         for traces in &group.traces {
-            Ink::write_traces(w, &traces);
+            Ink::write_traces(w, traces)?;
         }
-        w.write(XmlEvent::end_element());
+        w.write(XmlEvent::end_element())?;
+
+        Ok(())
     }
 
-    fn write_traces<W: Write>(w: &mut xml::EventWriter<W>, traces: &Traces) {
+    fn write_traces<W: Write>(w: &mut xml::EventWriter<W>, traces: &Traces) -> InkmlResult<()> {
         match traces {
             Traces::Trace(trace) => {
-                Ink::write_trace(w, &trace);
+                Ink::write_trace(w, trace)?;
             }
             Traces::TraceGroup(group) => {
-                Ink::write_tracegroup(w, &group);
+                Ink::write_tracegroup(w, group)?;
             }
         }
+
+        Ok(())
     }
 
-    fn write_definitions<W: Write>(w: &mut xml::EventWriter<W>, ink: &Ink) {
-        w.write(XmlEvent::start_element("definitions"));
-        w.write(XmlEvent::start_element("context").attr("xml:id", "ctx0"));
-        w.write(XmlEvent::start_element("inkSource").attr("xml:id", "inkSrc0"));
+    fn write_definitions<W: Write>(w: &mut xml::EventWriter<W>, _ink: &Ink) -> InkmlResult<()> {
+        w.write(XmlEvent::start_element("definitions"))?;
+        w.write(XmlEvent::start_element("context").attr("xml:id", "ctx0"))?;
+        w.write(XmlEvent::start_element("inkSource").attr("xml:id", "inkSrc0"))?;
 
-        w.write(XmlEvent::start_element("traceFormat"));
+        w.write(XmlEvent::start_element("traceFormat"))?;
         w.write(
             XmlEvent::start_element("channel")
                 .attr("name", "X")
                 .attr("type", "integer"),
-        );
-        w.write(XmlEvent::end_element()); // channel
+        )?;
+        w.write(XmlEvent::end_element())?; // channel
         w.write(
             XmlEvent::start_element("channel")
                 .attr("name", "Y")
                 .attr("type", "integer"),
-        );
-        w.write(XmlEvent::end_element()); // channel
+        )?;
+        w.write(XmlEvent::end_element())?; // channel
 
-        w.write(XmlEvent::end_element()); // traceFormat
-        w.write(XmlEvent::end_element()); // inkSource
-        w.write(XmlEvent::end_element()); // context
+        w.write(XmlEvent::end_element())?; // traceFormat
+        w.write(XmlEvent::end_element())?; // inkSource
+        w.write(XmlEvent::end_element())?; // context
 
-        w.write(XmlEvent::start_element("brush").attr("xml:id", "br0"));
+        w.write(XmlEvent::start_element("brush").attr("xml:id", "br0"))?;
         w.write(
             XmlEvent::start_element("brushProperty")
                 .attr("name", "width")
                 .attr("value", "3")
                 .attr("units", "mm"),
-        );
-        w.write(XmlEvent::end_element());
+        )?;
+        w.write(XmlEvent::end_element())?;
         w.write(
             XmlEvent::start_element("brushProperty")
                 .attr("name", "height")
                 .attr("value", "3")
                 .attr("units", "mm"),
-        );
-        w.write(XmlEvent::end_element());
+        )?;
+        w.write(XmlEvent::end_element())?;
         w.write(
             XmlEvent::start_element("brushProperty")
                 .attr("name", "color")
                 .attr("value", "\\#FFFFFF"),
-        );
-        w.write(XmlEvent::end_element());
-        w.write(XmlEvent::end_element()); // brush
+        )?;
+        w.write(XmlEvent::end_element())?;
+        w.write(XmlEvent::end_element())?; // brush
 
-        w.write(XmlEvent::end_element()); // definitions
+        w.write(XmlEvent::end_element())?; // definitions
+
+        Ok(())
     }
 
-    pub fn write_to<W: Write>(&mut self, w: &mut W) -> Result<(), Box<dyn Error>> {
+    pub fn write_to<W: Write>(&mut self, w: &mut W) -> InkmlResult<()> {
         // Set up EventWriter
         let mut writer = EmitterConfig::new().perform_indent(true).create_writer(w);
 
@@ -171,23 +176,23 @@ impl<'a> Ink {
             version: xml::common::XmlVersion::Version10,
             encoding: Some("UTF-8"),
             standalone: Some(true),
-        });
+        })?;
         // Iterate over and write events for inner nodes
-        self.iter().for_each(|n| match n {
+        self.iter().map(|n| match n {
             Node::Ink(ink) => {
                 writer.write(
                     XmlEvent::start_element("ink").ns("inkml", "https://www.w3.org/TR/InkML"),
-                );
+                )?;
 
-                Ink::write_definitions(&mut writer, &ink);
+                Ink::write_definitions(&mut writer, ink)
             }
 
             Node::Traces(traces) => {
-                Ink::write_traces(&mut writer, &traces);
+                Ink::write_traces(&mut writer, traces)
             }
-        });
+        }).collect::<InkmlResult<Vec<_>>>()?;
 
-        writer.write(XmlEvent::end_element());
+        writer.write(XmlEvent::end_element())?;
         Ok(())
     }
 }
@@ -198,8 +203,8 @@ impl<'a> IntoIterator for &'a Ink {
 
     fn into_iter(self) -> NodeIter<'a> {
         let mut queue = VecDeque::new();
-        queue.push_back(Node::Ink(&self));
+        queue.push_back(Node::Ink(self));
 
-        NodeIter { queue: queue }
+        NodeIter { queue }
     }
 }

--- a/crates/inkmlrs/src/main.rs
+++ b/crates/inkmlrs/src/main.rs
@@ -104,8 +104,11 @@ impl State {
         if let Some(ink) = &self.document {
             graphics::set_canvas(ctx, Some(&self.canvas));
 
-            ink.iter().for_each(|n| if let inkml::Node::Traces(inkml::Traces::Trace(inkml::Trace { ref vertices })) = n {
-                draw_trace!(ctx, vertices)
+            ink.iter().for_each(|n| {
+                if let inkml::Node::Traces(inkml::Traces::Trace(inkml::Trace { ref vertices })) = n
+                {
+                    draw_trace!(ctx, vertices)
+                }
             });
 
             graphics::set_canvas(ctx, None);

--- a/crates/inkmlrs/src/main.rs
+++ b/crates/inkmlrs/src/main.rs
@@ -3,6 +3,7 @@ extern crate ggez;
 extern crate structopt;
 extern crate xml;
 
+mod error;
 mod inkml;
 mod parse;
 

--- a/crates/inkmlrs/src/parse.rs
+++ b/crates/inkmlrs/src/parse.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use xml::name::OwnedName;
 use xml::reader::{EventReader, XmlEvent};
 
-use crate::error::{InkmlResult, InkmlError};
+use crate::error::{InkmlError, InkmlResult};
 use crate::inkml::{Ink, Trace, TraceGroup, Traces};
 
 pub type Point = [f32; 2];
@@ -92,7 +92,9 @@ pub fn parse_inkml<R: Read>(inkml: R) -> InkmlResult<Ink> {
             }
 
             XmlEvent::Characters(contents) => {
-                if let (Some("trace"), Some(&mut Node::Trace(Trace { ref mut vertices }))) = (name_stack.last().map(|s| &s[..]), parse_stack.last_mut()) {
+                if let (Some("trace"), Some(&mut Node::Trace(Trace { ref mut vertices }))) =
+                    (name_stack.last().map(|s| &s[..]), parse_stack.last_mut())
+                {
                     vertices.append(&mut parse_vertices(contents));
                 }
             }

--- a/crates/inkmlrs/src/parse.rs
+++ b/crates/inkmlrs/src/parse.rs
@@ -22,8 +22,8 @@ fn parse_vertices(data: String) -> Vec<Point> {
                 .split(' ')
                 .filter_map(|s| s.parse::<f32>().ok())
                 .collect::<Vec<_>>();
-            if xy.len() > 0 {
-                Some([xy[0].clone(), xy[1].clone()])
+            if xy.is_empty() {
+                Some([xy[0], xy[1]])
             } else {
                 None
             }
@@ -67,7 +67,7 @@ pub fn parse_inkml<R: Read>(inkml: R) -> Result<Ink, Box<dyn Error>> {
 
                     match node {
                         Node::Ink(ink) => {
-                            if let None = top {
+                            if top.is_none() {
                                 root = ink;
                             }
                         }
@@ -87,19 +87,13 @@ pub fn parse_inkml<R: Read>(inkml: R) -> Result<Ink, Box<dyn Error>> {
                             }
                             _ => {}
                         },
-
-                        _ => {}
                     }
                 }
             }
 
             XmlEvent::Characters(contents) => {
-                match (name_stack.last().map(|s| &s[..]), parse_stack.last_mut()) {
-                    (Some("trace"), Some(&mut Node::Trace(Trace { ref mut vertices }))) => {
-                        vertices.append(&mut parse_vertices(contents));
-                    }
-
-                    _ => {}
+                if let (Some("trace"), Some(&mut Node::Trace(Trace { ref mut vertices }))) = (name_stack.last().map(|s| &s[..]), parse_stack.last_mut()) {
+                    vertices.append(&mut parse_vertices(contents));
                 }
             }
             _ => {}

--- a/flake-parts/cargo.nix
+++ b/flake-parts/cargo.nix
@@ -65,6 +65,7 @@
       inherit (common-build-args) src;
       hooks = {
         alejandra.enable = true;
+        rustfmt.enable = true;
       };
     };
 


### PR DESCRIPTION
- Runs `cargo clippy`
- Enables pre-commit-hook for rustfmt
- Implements a custom error type, enabling `?` to be used in place of unwrap